### PR TITLE
Fix typo for literal in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Testing `type` is done first, and it soon determines if the object is `"person"`
 
 ### Literals
 
-* `literal(lit)` The value must `=== lit`
+* `literal(lit)` The value must `== lit`
 
 ### Shortcuts
 


### PR DESCRIPTION
I guess the literal type uses `==` method to compare.
https://github.com/soutaro/strong_json/blob/master/lib/strong_json/type.rb#L101