### PR TITLE
Remove useless `coerce` call to optimize enum type

### DIFF
--- a/lib/strong_json/type.rb
+++ b/lib/strong_json/type.rb
@@ -204,10 +204,15 @@ class StrongJSON
       end
 
       def coerce(value, path: [])
-        type = types.find {|ty| ty =~ value }
+        result = types.find do |ty|
+          begin
+            break ty.coerce(value)
+          rescue UnexpectedFieldError, IllegalTypeError, Error # rubocop:disable Lint/HandleExceptions
+          end
+        end
 
-        if type
-          type.coerce(value, path: path)
+        if result
+          result
         else
           raise Error.new(path: path, type: self, value: value)
         end


### PR DESCRIPTION
`coerce` method is called once wastefully in enum type.
This change removes useless call.

Benchmark
=======

```ruby
 # bench.rb
require 'benchmark'
require 'strong_json'

s = StrongJSON.new do
  let :test, enum(string, number, boolean)
end

Benchmark.bm(20) do |x|
  x.report('string') {1000000.times{s.test.coerce('foo')}}
  x.report('number') {1000000.times{s.test.coerce(42)}}
  x.report('boolean'){1000000.times{s.test.coerce(true)}}
end
```

```bash
 # before
$ ruby bench.rb
                           user     system      total        real
string                 1.000000   0.000000   1.000000 (  1.000055)
number                 2.660000   0.000000   2.660000 (  2.666975)
boolean                4.240000   0.000000   4.240000 (  4.239681)

 # after
$ ruby bench.rb
                           user     system      total        real
string                 0.680000   0.000000   0.680000 (  0.681966)
number                 2.480000   0.000000   2.480000 (  2.482622)
boolean                4.150000   0.000000   4.150000 (  4.143135)
```