### PR TITLE
Add a shorthand for `optional(any)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ There are some alias for `optional(base)`, where base is base types, as the foll
 * `numeric?`
 * `symbol?`
 * `literal?(lit)`
+* `any?`
 
 Shorthands for `optional(array(ty))` and `optional(object(fields))` are also defined as the following:
 

--- a/lib/strong_json/types.rb
+++ b/lib/strong_json/types.rb
@@ -32,6 +32,10 @@ class StrongJSON
       StrongJSON::Type::Base.new(:any)
     end
 
+    def any?
+      optional(any)
+    end
+
     def prohibited
       StrongJSON::Type::Base.new(:prohibited)
     end


### PR DESCRIPTION
`any?` is like `ignored`, but `any?` returns received value.

```ruby
require 'strong_json'

s = StrongJSON.new do
  let :a, object(x: ignored)
  let :b, object(x: any?)
end

p s.a.coerce({x: 1}) # => {}
p s.b.coerce({x: 1}) # => {x: 1}
```