### PR TITLE
Add homepage URL to the gemspec

### DIFF
--- a/strong_json.gemspec
+++ b/strong_json.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["matsumoto@soutaro.com"]
   spec.summary       = "Type check JSON objects"
   spec.description   = "Type check JSON objects"
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/soutaro/strong_json"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
By this change:

1. Users can jump to this repository on GitHub from rubygems.org
2. Maybe users can jump to this repository on GitHub from deppbot



1
![170830170049](https://user-images.githubusercontent.com/4361134/29861674-f541df46-8da4-11e7-8a88-b3a68814f482.png)


2
![170830165942](https://user-images.githubusercontent.com/4361134/29861593-b8b3456a-8da4-11e7-82e3-c56a7bc8ca4c.png)

