### PR TITLE
Fix `Type::Object#merge` behavior when object instance is passed

### DIFF
--- a/lib/strong_json/type.rb
+++ b/lib/strong_json/type.rb
@@ -167,7 +167,7 @@ class StrongJSON
 
       def merge(fields)
         if fields.is_a?(Object)
-          fields = Object.instance_variable_get("@fields")
+          fields = fields.instance_variable_get("@fields")
         end
 
         Object.new(@fields.merge(fields))

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -65,6 +65,18 @@ describe StrongJSON::Type::Object do
 
       expect{ ty2.coerce(a: 123) }.to raise_error(StrongJSON::Type::Error)
     end
+
+    it "adds field via object" do
+      ty2 = type.merge(StrongJSON::Type::Object.new(b: StrongJSON::Type::Base.new(:string)))
+
+      expect(ty2.coerce(a: 123, b: "test")).to eq(a: 123, b: "test")
+    end
+
+    it "overrides field via object" do
+      ty2 = type.merge(StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:prohibited)))
+
+      expect{ ty2.coerce(a: 123) }.to raise_error(StrongJSON::Type::Error)
+    end
   end
 
   describe "#except" do


### PR DESCRIPTION
The following error is raised:

    TypeError:
      no implicit conversion of nil into Hash
    # ./lib/strong_json/type.rb:173:in `merge'
    # ./lib/strong_json/type.rb:173:in `merge'
    # ./spec/object_spec.rb:76:in `block (3 levels) in <top (required)>'