### PR TITLE
Add `enum?` shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,11 @@ There are some alias for `optional(base)`, where base is base types, as the foll
 * `literal?(lit)`
 * `any?`
 
-Shorthands for `optional(array(ty))` and `optional(object(fields))` are also defined as the following:
+Shortcuts for complex data are also defined as the following:
 
-* `array?(ty)`
-* `object?(fields)`
+* `optional(array(ty))` → `array?(ty)`
+* `optional(object(fields))` → `object?(fields)`
+* `optional(enum(types))` → `enum?(types)`
 
 ## Contributing
 

--- a/lib/strong_json/types.rb
+++ b/lib/strong_json/types.rb
@@ -87,5 +87,9 @@ class StrongJSON
     def literal?(value)
       optional(literal(value))
     end
+
+    def enum?(*types)
+      optional(enum(*types))
+    end
   end
 end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -9,4 +9,17 @@ describe "StrongJSON.new" do
 
     expect(s.checkout.coerce(items: [ { name: "test", count: 1, price: "2.33", comment: "dummy" }], type: 1)).to eq(items: [ { name: "test", count: 1, price: "2.33" }], type: 1)
   end
+
+  it "tests enums" do
+    s = StrongJSON.new do
+      let :enum, object(e1: enum(string, number), e2: enum?(literal(1), literal(2)))
+    end
+
+    expect(s.enum.coerce(e1: "")).to eq(e1: "")
+    expect(s.enum.coerce(e1: 0)).to eq(e1: 0)
+    expect(s.enum.coerce(e1: 0, e2: 1)).to eq(e1: 0, e2: 1)
+    expect(s.enum.coerce(e1: 0, e2: 2)).to eq(e1: 0, e2: 2)
+    expect{ s.enum.coerce(e1: false) }.to raise_error(StrongJSON::Type::Error)
+    expect{ s.enum.coerce(e1: "", e2: 3) }.to raise_error(StrongJSON::Type::Error)
+  end
 end


### PR DESCRIPTION
Hi! 

This adds a new convenient shortcut for `optional(enum(types))`.

E.g.

```ruby
s = StrongJSON.new do
  let :enum, enum?(literal(1), literal(2))
  # same as
  # let :enum, optional(enum(literal(1), literal(2)))
end
```
