### PR TITLE
Make boolean false available in `enum(boolean)`

### DIFF
--- a/lib/strong_json/type.rb
+++ b/lib/strong_json/type.rb
@@ -80,7 +80,7 @@ class StrongJSON
       end
 
       def to_s
-        "optinal(#{@type})"
+        "optional(#{@type})"
       end
     end
 
@@ -211,10 +211,10 @@ class StrongJSON
           end
         end
 
-        if result
-          result
-        else
+        if result.nil?
           raise Error.new(path: path, type: self, value: value)
+        else
+          result
         end
       end
     end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -12,14 +12,14 @@ describe "StrongJSON.new" do
 
   it "tests enums" do
     s = StrongJSON.new do
-      let :enum, object(e1: enum(string, number), e2: enum?(literal(1), literal(2)))
+      let :enum, object(e1: enum(boolean, number), e2: enum?(literal(1), literal(2)))
     end
 
-    expect(s.enum.coerce(e1: "")).to eq(e1: "")
+    expect(s.enum.coerce(e1: false)).to eq(e1: false)
     expect(s.enum.coerce(e1: 0)).to eq(e1: 0)
     expect(s.enum.coerce(e1: 0, e2: 1)).to eq(e1: 0, e2: 1)
     expect(s.enum.coerce(e1: 0, e2: 2)).to eq(e1: 0, e2: 2)
-    expect{ s.enum.coerce(e1: false) }.to raise_error(StrongJSON::Type::Error)
     expect{ s.enum.coerce(e1: "", e2: 3) }.to raise_error(StrongJSON::Type::Error)
+    expect{ s.enum.coerce(e1: false, e2: "") }.to raise_error(StrongJSON::Type::Error)
   end
 end


### PR DESCRIPTION
Presently, type checkings are failed when putting boolean false in an enum.

Reproduce example:

```
# Schema example,
object = StrongJSON.new do
  let :enum_obj, object(item: enum(boolean, string))
end

# JSON example for the schema.
{
  'item' => {
    'item' => false
  }
}
```

This seems that `Enum#coerece` returns `Error.new` when `false` is set in `enum(boolean)` because `result` makes `false`. Thus, I tried to prevent from failing to schema checks in this case.

What do you think about?