### PR TITLE
Support `detector` for enum

### DIFF
--- a/lib/strong_json/type.rb
+++ b/lib/strong_json/type.rb
@@ -202,11 +202,13 @@ class StrongJSON
     class Enum
       include Match
 
-      # @dynamic types
+      # @dynamic types, detector
       attr_reader :types
+      attr_reader :detector
 
-      def initialize(types)
+      def initialize(types, detector = nil)
         @types = types
+        @detector = detector
       end
 
       def to_s
@@ -214,6 +216,13 @@ class StrongJSON
       end
 
       def coerce(value, path: [])
+        if d = detector
+          type = d[value]
+          if type && types.include?(type)
+            return type.coerce(value, path: path)
+          end
+        end
+
         types.each do |ty|
           begin
             return ty.coerce(value, path: path)

--- a/lib/strong_json/types.rb
+++ b/lib/strong_json/types.rb
@@ -51,8 +51,8 @@ class StrongJSON
       StrongJSON::Type::Literal.new(value)
     end
 
-    def enum(*types)
-      StrongJSON::Type::Enum.new(types)
+    def enum(*types, detector: nil)
+      StrongJSON::Type::Enum.new(types, detector)
     end
 
     def string?
@@ -91,8 +91,8 @@ class StrongJSON
       optional(literal(value))
     end
 
-    def enum?(*types)
-      optional(enum(*types))
+    def enum?(*types, detector: nil)
+      optional(enum(*types, detector: detector))
     end
   end
 end

--- a/sig/strong_json.rbi
+++ b/sig/strong_json.rbi
@@ -37,8 +37,8 @@ module StrongJSON::Types
   def array?: <'x> (_Schema<'x>) -> _Schema<Array<'x>?>
   def literal: <'x> ('x) -> _Schema<'x>
   def literal?: <'x> ('x) -> _Schema<'x?>
-  def enum: <'x> (*_Schema<any>) -> _Schema<'x>
-  def enum?: <'x> (*_Schema<any>) -> _Schema<'x?>
+  def enum: <'x> (*_Schema<any>, ?detector: Type::detector?) -> _Schema<'x>
+  def enum?: <'x> (*_Schema<any>, ?detector: Type::detector?) -> _Schema<'x?>
   def ignored: () -> _Schema<nil>
   def prohibited: () -> _Schema<nil>
 end

--- a/sig/type.rbi
+++ b/sig/type.rbi
@@ -59,12 +59,15 @@ class StrongJSON::Type::Object<'t>
   def except: (*Symbol) -> Object<any>
 end
 
+type StrongJSON::Type::detector = ^(any) -> _Schema<any>?
+
 class StrongJSON::Type::Enum<'t>
   include Match
 
   attr_reader types: ::Array<_Schema<any>>
+  attr_reader detector: detector?
 
-  def initialize: (::Array<_Schema<any>>) -> any
+  def initialize: (::Array<_Schema<any>>, ?detector?) -> any
   def coerce: (any, ?path: ::Array<Symbol>) -> 't
 end
 


### PR DESCRIPTION
You can pass an optional `detector:` lambda to `enum`. The detector should return a schema for a given object, which identifies which part of the enum should be used.

```rb
let :person_address, object(first_name: string, given_name: string, email: string)
let :company_address, object(name: string, email: string, address: string)
let :address, enum(person_address, company_address, detector: -> (value) {
  case 
  when value.is_a?(Hash) && value[:name]
    company_address
  when value.is_a?(Hash) && value[:first_name]
    person_address
  end
})
```

Using `detector` helps:

* Making type check faster
* Generating user friendly error message