### PR TITLE
Fix signature

### DIFF
--- a/example/example.rb
+++ b/example/example.rb
@@ -3,7 +3,7 @@ Schema = _ = StrongJSON.new do
 
   let :address, object(address: string, country: symbol?)
   let :email, object(email: string)
-  let :contact, enum(address, email)
+  let :contact, enum?(address, email)
   let :person, object(name: string, contacts: array(contact))
 end
 

--- a/example/example.rbi
+++ b/example/example.rbi
@@ -2,10 +2,10 @@ type address = { address: String, country: Symbol? }
 type email = { email: String }
 
 class AddressSchema < StrongJSON
-  def address: -> StrongJSON::_Schema<address>
-  def email: -> StrongJSON::_Schema<email>
-  def contact: -> StrongJSON::_Schema<email | address>
-  def person: -> StrongJSON::_Schema<{ name: String, contacts: Array<email | address> }>
+  def address: -> StrongJSON::Type::Object<address>
+  def email: -> StrongJSON::Type::Object<email>
+  def contact: -> StrongJSON::Type::Object<email | address>
+  def person: -> StrongJSON::Type::Object<{ name: String, contacts: Array<email | address> }>
 end
 
 Schema: AddressSchema

--- a/lib/strong_json/types.rb
+++ b/lib/strong_json/types.rb
@@ -1,16 +1,16 @@
 class StrongJSON
   module Types
-    # @type method object: (?Hash<Symbol, ty>) -> _Schema<any>
+    # @type method object: (?Hash<Symbol, ty>) -> Type::Object<any>
     def object(fields = {})
       Type::Object.new(fields)
     end
 
-    # @type method array: (?ty) -> _Schema<any>
+    # @type method array: (?ty) -> Type::Array<any>
     def array(type = any)
       Type::Array.new(type)
     end
 
-    # @type method optional: (?ty) -> _Schema<any>
+    # @type method optional: (?ty) -> Type::Optional<any>
     def optional(type = any)
       Type::Optional.new(type)
     end

--- a/sig/strong_json.rbi
+++ b/sig/strong_json.rbi
@@ -16,29 +16,29 @@ end
 type StrongJSON::ty = _Schema<any>
 
 module StrongJSON::Types
-  def object: <'x> (Hash<Symbol, ty>) -> _Schema<'x>
-            | () -> _Schema<Hash<Symbol, any>>
-  def object?: <'x> (Hash<Symbol, ty>) -> _Schema<'x | nil>
-  def any: () -> _Schema<any>
-  def optional: <'x> (?_Schema<'x>) -> _Schema<'x | nil>
-              | () -> _Schema<any>
-  def string: () -> _Schema<String>
-  def string?: () -> _Schema<String?>
-  def number: () -> _Schema<Numeric>
-  def number?: () -> _Schema<Numeric?>
-  def numeric: () -> _Schema<Numeric>
-  def numeric?: () -> _Schema<Numeric?>
-  def boolean: () -> _Schema<bool>
-  def boolean?: () -> _Schema<bool?>
-  def symbol: () -> _Schema<Symbol>
-  def symbol?: () -> _Schema<Symbol?>
-  def array: <'x> (_Schema<'x>) -> _Schema<Array<'x>>
-           | () -> _Schema<Array<any>>
-  def array?: <'x> (_Schema<'x>) -> _Schema<Array<'x>?>
-  def literal: <'x> ('x) -> _Schema<'x>
-  def literal?: <'x> ('x) -> _Schema<'x?>
-  def enum: <'x> (*_Schema<any>) -> _Schema<'x>
-  def enum?: <'x> (*_Schema<any>) -> _Schema<'x?>
+  def object: <'x> (Hash<Symbol, ty>) -> Type::Object<'x>
+            | () -> Type::Object<Hash<Symbol, any>>
+  def object?: <'x> (Hash<Symbol, ty>) -> Type::Optional<'x>
+  def any: () -> Type::Base<any>
+  def optional: <'x> (_Schema<'x>) -> Type::Optional<'x>
+              | () -> Type::Optional<any>
+  def string: () -> Type::Base<String>
+  def string?: () -> Type::Optional<String>
+  def number: () -> Type::Base<Numeric>
+  def number?: () -> Type::Optional<Numeric>
+  def numeric: () -> Type::Base<Numeric>
+  def numeric?: () -> Type::Optional<Numeric>
+  def boolean: () -> Type::Base<bool>
+  def boolean?: () -> Type::Optional<bool>
+  def symbol: () -> Type::Base<Symbol>
+  def symbol?: () -> Type::Optional<Symbol>
+  def array: <'x> (_Schema<'x>) -> Type::Array<'x>
+           | () -> Type::Array<any>
+  def array?: <'x> (_Schema<'x>) -> Type::Optional<::Array<'x>>
+  def literal: <'x> ('x) -> Type::Literal<'x>
+  def literal?: <'x> ('x) -> Type::Optional<'x>
+  def enum: <'x> (*_Schema<any>) -> Type::Enum<'x>
+  def enum?: <'x> (*_Schema<any>) -> Type::Optional<'x>
   def ignored: () -> _Schema<nil>
   def prohibited: () -> _Schema<nil>
 end

--- a/strong_json.gemspec
+++ b/strong_json.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "steep", "~> 0.8"
+  spec.add_development_dependency "steep", "~> 0.10"
 end


### PR DESCRIPTION
Export raw types in `Types` module. This allows using type-specific methods like `Type::Object#merge`.