### PR TITLE
Revise error reporting

### DIFF
--- a/lib/strong_json.rb
+++ b/lib/strong_json.rb
@@ -1,6 +1,8 @@
 require "strong_json/version"
 require "strong_json/type"
 require "strong_json/types"
+require "strong_json/error_reporter"
+require "prettyprint"
 
 class StrongJSON
   def initialize(&block)

--- a/lib/strong_json.rb
+++ b/lib/strong_json.rb
@@ -8,7 +8,7 @@ class StrongJSON
   end
 
   def let(name, type)
-    define_singleton_method(name) { type }
+    define_singleton_method(name) { type.with_alias(name) }
   end
 
   include StrongJSON::Types

--- a/lib/strong_json/error_reporter.rb
+++ b/lib/strong_json/error_reporter.rb
@@ -1,0 +1,130 @@
+class StrongJSON
+  class ErrorReporter
+    # @dynamic path
+    attr_reader :path
+
+    def initialize(path:)
+      @path = path
+    end
+
+    def to_s
+      format() unless @string
+      @string
+    end
+
+    def format
+      @string = ""
+
+      format_trace(path: path)
+      where = format_aliases(path: path, where: [])
+      unless where.empty?
+        @string << "\nWhere:\n"
+        @string << where.map {|x| x.gsub(/^/, "  ") }.join("\n")
+      end
+    end
+
+    def format_trace(path:, index: 1)
+      @string << (" " * index)
+      type_string = pretty_str(path.type)
+      if parent = path.parent
+        case parent[0]
+        when Symbol
+          @string << "\"#{parent[0]}\" expected to be #{type_string}\n"
+        when Integer
+          @string << "#{parent[0]} expected to be #{type_string}\n"
+        else
+          @string << "Expected to be #{type_string}\n"
+        end
+
+        format_trace(path: parent[1], index: index + 1)
+      else
+        @string << "$ expected to be #{type_string}\n"
+      end
+    end
+
+    def format_aliases(path:, where:)
+      ty = path.type
+
+      if ty.alias
+        # @type const PrettyPrint: any
+        where << PrettyPrint.format do |pp|
+          pp.text(ty.alias.to_s)
+          pp.text(" = ")
+          pp.group do
+            pretty(ty, pp, expand_alias: true)
+          end
+        end
+      end
+
+      if parent = path.parent
+        format_aliases(path: parent[1], where: where)
+      end
+
+      where
+    end
+
+    def pretty_str(type, expand_alias: false)
+      # @type const PrettyPrint: any
+      PrettyPrint.singleline_format do |pp|
+        pretty(type, pp, expand_alias: expand_alias)
+      end
+    end
+
+    def pretty(type, pp, expand_alias: false)
+      if !expand_alias && type.alias
+        pp.text type.alias.to_s
+      else
+        case type
+        when Type::Object
+          pp.group 0, "{", "}" do
+            pp.nest(2) do
+              pp.breakable(" ")
+              type.fields.each.with_index do |pair, index|
+                key, ty = pair
+                pp.text "#{key.to_s.inspect}: "
+                pretty(ty, pp)
+                if index < type.fields.size-1
+                  pp.text ","
+                  pp.breakable(" ")
+                end
+              end
+            end
+            pp.breakable(" ")
+          end
+        when Type::Enum
+          pp.group 0, "enum(", ")" do
+            pp.nest(2) do
+              pp.breakable("")
+              type.types.each.with_index do |ty, index|
+                pretty(ty, pp)
+                if index < type.types.size - 1
+                  pp.text ","
+                  pp.breakable " "
+                end
+              end
+            end
+            pp.breakable("")
+          end
+        when Type::Optional
+          pp.group 0, "optional(", ")" do
+            pp.nest(2) do
+              pp.breakable ""
+              pretty(type.type, pp)
+            end
+            pp.breakable ""
+          end
+        when Type::Array
+          pp.group 0, "array(", ")" do
+            pp.nest(2) do
+              pp.breakable ""
+              pretty(type.type, pp)
+            end
+            pp.breakable ""
+          end
+        else
+          pp.text type.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/strong_json/type.rb
+++ b/lib/strong_json/type.rb
@@ -202,11 +202,13 @@ class StrongJSON
     class Enum
       include Match
 
-      # @dynamic types
+      # @dynamic types, detector
       attr_reader :types
+      attr_reader :detector
 
-      def initialize(types)
+      def initialize(types, detector = nil)
         @types = types
+        @detector = detector
       end
 
       def to_s
@@ -214,6 +216,13 @@ class StrongJSON
       end
 
       def coerce(value, path: [])
+        if d = detector
+          type = d[value]
+          if type && types.include?(type)
+            return type.coerce(value, path: path)
+          end
+        end
+
         types.each do |ty|
           begin
             return ty.coerce(value, path: path)

--- a/lib/strong_json/type.rb
+++ b/lib/strong_json/type.rb
@@ -13,8 +13,23 @@ class StrongJSON
       end
     end
 
+    module WithAlias
+      def alias
+        @alias
+      end
+
+      def with_alias(name)
+        _ = dup.tap do |copy|
+          copy.instance_eval do
+            @alias = name
+          end
+        end
+      end
+    end
+
     class Base
       include Match
+      include WithAlias
 
       # @dynamic type
       attr_reader :type
@@ -60,6 +75,7 @@ class StrongJSON
 
     class Optional
       include Match
+      include WithAlias
 
       def initialize(type)
         @type = type
@@ -80,6 +96,7 @@ class StrongJSON
 
     class Literal
       include Match
+      include WithAlias
 
       # @dynamic value
       attr_reader :value
@@ -100,6 +117,7 @@ class StrongJSON
 
     class Array
       include Match
+      include WithAlias
 
       def initialize(type)
         @type = type
@@ -122,6 +140,7 @@ class StrongJSON
 
     class Object
       include Match
+      include WithAlias
 
       # @dynamic fields, ignored_attributes, prohibited_attributes
       attr_reader :fields, :ignored_attributes, :prohibited_attributes
@@ -208,6 +227,7 @@ class StrongJSON
 
     class Enum
       include Match
+      include WithAlias
 
       # @dynamic types, detector
       attr_reader :types

--- a/lib/strong_json/type.rb
+++ b/lib/strong_json/type.rb
@@ -69,7 +69,7 @@ class StrongJSON
       end
 
       def to_s
-        @type.to_s
+        self.alias&.to_s || @type.to_s
       end
 
       def ==(other)
@@ -104,7 +104,7 @@ class StrongJSON
       end
 
       def to_s
-        "optional(#{@type})"
+        self.alias&.to_s || "optional(#{@type})"
       end
 
       def ==(other)
@@ -131,7 +131,7 @@ class StrongJSON
       end
 
       def to_s
-        (_ = @value).inspect
+        self.alias&.to_s || (_ = @value).inspect
       end
 
       def coerce(value, path: ErrorPath.root(self))
@@ -173,7 +173,7 @@ class StrongJSON
       end
 
       def to_s
-        "array(#{@type})"
+        self.alias&.to_s || "array(#{@type})"
       end
 
       def ==(other)
@@ -271,7 +271,7 @@ class StrongJSON
           "#{name}: #{type}"
         end
 
-        "object(#{fields.join(', ')})"
+        self.alias&.to_s || "object(#{fields.join(', ')})"
       end
 
       def ==(other)
@@ -302,7 +302,7 @@ class StrongJSON
       end
 
       def to_s
-        "enum(#{types.map(&:to_s).join(", ")})"
+        self.alias&.to_s || "enum(#{types.map(&:to_s).join(", ")})"
       end
 
       def coerce(value, path: ErrorPath.root(self))

--- a/lib/strong_json/types.rb
+++ b/lib/strong_json/types.rb
@@ -2,7 +2,11 @@ class StrongJSON
   module Types
     # @type method object: (?Hash<Symbol, ty>) -> Type::Object<any>
     def object(fields = {})
-      Type::Object.new(fields)
+      if fields.empty?
+        Type::Object.new(fields, ignored_attributes: nil, prohibited_attributes: Set.new)
+      else
+        Type::Object.new(fields, ignored_attributes: :any, prohibited_attributes: Set.new)
+      end
     end
 
     # @type method array: (?ty) -> Type::Array<any>
@@ -39,10 +43,6 @@ class StrongJSON
       optional(any)
     end
 
-    def prohibited
-      StrongJSON::Type::Base.new(:prohibited)
-    end
-
     def symbol
       StrongJSON::Type::Base.new(:symbol)
     end
@@ -75,15 +75,12 @@ class StrongJSON
       optional(symbol)
     end
 
-    def ignored
-      StrongJSON::Type::Base.new(:ignored)
-    end
-
     def array?(ty)
       optional(array(ty))
     end
 
-    def object?(fields)
+    # @type method object?: (?Hash<Symbol, ty>) -> Type::Optional<any>
+    def object?(fields={})
       optional(object(fields))
     end
 

--- a/lib/strong_json/types.rb
+++ b/lib/strong_json/types.rb
@@ -51,8 +51,8 @@ class StrongJSON
       StrongJSON::Type::Literal.new(value)
     end
 
-    def enum(*types)
-      StrongJSON::Type::Enum.new(types)
+    def enum(*types, detector: nil)
+      StrongJSON::Type::Enum.new(types, detector)
     end
 
     def string?
@@ -91,8 +91,8 @@ class StrongJSON
       optional(literal(value))
     end
 
-    def enum?(*types)
-      optional(enum(*types))
+    def enum?(*types, detector: nil)
+      optional(enum(*types, detector: detector))
     end
   end
 end

--- a/sig/strong_json.rbi
+++ b/sig/strong_json.rbi
@@ -37,8 +37,8 @@ module StrongJSON::Types
   def array?: <'x> (_Schema<'x>) -> Type::Optional<::Array<'x>>
   def literal: <'x> ('x) -> Type::Literal<'x>
   def literal?: <'x> ('x) -> Type::Optional<'x>
-  def enum: <'x> (*_Schema<any>) -> Type::Enum<'x>
-  def enum?: <'x> (*_Schema<any>) -> Type::Optional<'x>
+  def enum: <'x> (*_Schema<any>, ?detector: Type::detector?) -> Type::Enum<'x>
+  def enum?: <'x> (*_Schema<any>, ?detector: Type::detector?) -> Type::Optional<'x>
   def ignored: () -> _Schema<nil>
   def prohibited: () -> _Schema<nil>
 end

--- a/sig/strong_json.rbi
+++ b/sig/strong_json.rbi
@@ -15,6 +15,8 @@ interface StrongJSON::_Schema<'type>
   def =~: (any) -> bool
   def to_s: -> String
   def is_a?: (any) -> bool
+  def alias: -> Symbol?
+  def with_alias: (Symbol) -> self
 end
 
 type StrongJSON::ty = _Schema<any>

--- a/sig/strong_json.rbi
+++ b/sig/strong_json.rbi
@@ -21,8 +21,9 @@ type StrongJSON::ty = _Schema<any>
 
 module StrongJSON::Types
   def object: <'x> (Hash<Symbol, ty>) -> Type::Object<'x>
-            | () -> Type::Object<Hash<Symbol, any>>
+            | () -> Type::Object<{}>
   def object?: <'x> (Hash<Symbol, ty>) -> Type::Optional<'x>
+             | () -> Type::Optional<{}>
   def any: () -> Type::Base<any>
   def optional: <'x> (_Schema<'x>) -> Type::Optional<'x>
               | () -> Type::Optional<any>
@@ -43,6 +44,4 @@ module StrongJSON::Types
   def literal?: <'x> ('x) -> Type::Optional<'x>
   def enum: <'x> (*_Schema<any>, ?detector: Type::detector?) -> Type::Enum<'x>
   def enum?: <'x> (*_Schema<any>, ?detector: Type::detector?) -> Type::Optional<'x>
-  def ignored: () -> _Schema<nil>
-  def prohibited: () -> _Schema<nil>
 end

--- a/sig/strong_json.rbi
+++ b/sig/strong_json.rbi
@@ -6,8 +6,12 @@ end
 
 StrongJSON::VERSION: String
 
+class StandardError
+  def initialize: (String) -> any
+end
+
 interface StrongJSON::_Schema<'type>
-  def coerce: (any, ?path: ::Array<Symbol>) -> 'type
+  def coerce: (any, ?path: Type::ErrorPath) -> 'type
   def =~: (any) -> bool
   def to_s: -> String
   def is_a?: (any) -> bool

--- a/sig/strong_json.rbi
+++ b/sig/strong_json.rbi
@@ -17,6 +17,8 @@ interface StrongJSON::_Schema<'type>
   def is_a?: (any) -> bool
   def alias: -> Symbol?
   def with_alias: (Symbol) -> self
+  def ==: (any) -> bool
+  def yield_self: <'a> () { (self) -> 'a } -> 'a
 end
 
 type StrongJSON::ty = _Schema<any>
@@ -46,4 +48,15 @@ module StrongJSON::Types
   def literal?: <'x> ('x) -> Type::Optional<'x>
   def enum: <'x> (*_Schema<any>, ?detector: Type::detector?) -> Type::Enum<'x>
   def enum?: <'x> (*_Schema<any>, ?detector: Type::detector?) -> Type::Optional<'x>
+end
+
+class StrongJSON::ErrorReporter
+  attr_reader path: Type::ErrorPath
+  @string: String
+  def initialize: (path: Type::ErrorPath) -> any
+  def format: -> void
+  def (private) format_trace: (path: Type::ErrorPath, ?index: Integer) -> void
+  def (private) format_aliases: (path: Type::ErrorPath, where: ::Array<String>) -> ::Array<String>
+  def (private) pretty: (ty, any, ?expand_alias: bool) -> void
+  def pretty_str: (ty, ?expand_alias: bool) -> ::String
 end

--- a/sig/type.rbi
+++ b/sig/type.rbi
@@ -29,7 +29,7 @@ class StrongJSON::Type::Optional<'t>
   include Match
   include WithAlias
 
-  @type: _Schema<'t>
+  attr_reader type: _Schema<'t>
 
   def initialize: (_Schema<'t>) -> any
   def coerce: (any, ?path: ErrorPath) -> ('t | nil)
@@ -49,7 +49,7 @@ class StrongJSON::Type::Array<'t>
   include Match
   include WithAlias
 
-  @type: _Schema<'t>
+  attr_reader type: _Schema<'t>
 
   def initialize: (_Schema<'t>) -> any
   def coerce: (any, ?path: ErrorPath) -> ::Array<'t>

--- a/sig/type.rbi
+++ b/sig/type.rbi
@@ -1,14 +1,12 @@
 module StrongJSON::Type
 end
 
-StrongJSON::Type::NONE: any
-
 module StrongJSON::Type::Match: _Schema<any>
   def =~: (any) -> bool
   def ===: (any) -> bool
 end
 
-type StrongJSON::base_type_name = :ignored | :any | :number | :string | :boolean | :numeric | :symbol | :prohibited
+type StrongJSON::base_type_name = :any | :number | :string | :boolean | :numeric | :symbol
 
 class StrongJSON::Type::Base<'a>
   include Match
@@ -50,13 +48,18 @@ end
 class StrongJSON::Type::Object<'t>
   include Match
 
-  @fields: Hash<Symbol, _Schema<'t>>
+  attr_reader fields: Hash<Symbol, _Schema<any>>
+  attr_reader ignored_attributes: :any | Set<Symbol> | nil
+  attr_reader prohibited_attributes: Set<Symbol>
 
-  def initialize: (Hash<Symbol, _Schema<'t>>) -> any
+  def initialize: (Hash<Symbol, _Schema<'t>>, ignored_attributes: :any | Set<Symbol> | nil, prohibited_attributes: Set<Symbol>) -> any
   def coerce: (any, ?path: ErrorPath) -> 't
-  def test_value_type: <'x, 'y> (ErrorPath, _Schema<'x>, any) { ('x) -> 'y } -> 'y
-  def merge: (Object<any> | Hash<Symbol, _Schema<any>>) -> Object<any>
-  def except: (*Symbol) -> Object<any>
+
+  def ignore: (:any | Set<Symbol> | nil) -> self
+  def ignore!: (:any | Set<Symbol> | nil) -> self
+  def prohibit: (Set<Symbol>) -> self
+  def prohibit!: (Set<Symbol>) -> self
+  def update_fields: <'x> { (Hash<Symbol, _Schema<any>>) -> void } -> Object<'x>
 end
 
 type StrongJSON::Type::detector = ^(any) -> _Schema<any>?
@@ -99,7 +102,3 @@ class StrongJSON::Type::UnexpectedAttributeError < StandardError
   def type: -> _Schema<any>
 end
 
-class StrongJSON::Type::IllegalTopTypeError < StandardError
-  attr_reader type: ty
-  def initialize: (type: ty) -> any
-end

--- a/sig/type.rbi
+++ b/sig/type.rbi
@@ -6,10 +6,17 @@ module StrongJSON::Type::Match: _Schema<any>
   def ===: (any) -> bool
 end
 
+module StrongJSON::Type::WithAlias: ::Object
+  @alias: Symbol?
+  def alias: -> Symbol?
+  def with_alias: (Symbol) -> self
+end
+
 type StrongJSON::base_type_name = :any | :number | :string | :boolean | :numeric | :symbol
 
 class StrongJSON::Type::Base<'a>
   include Match
+  include WithAlias
 
   attr_reader type: base_type_name
 
@@ -20,6 +27,7 @@ end
 
 class StrongJSON::Type::Optional<'t>
   include Match
+  include WithAlias
 
   @type: _Schema<'t>
 
@@ -29,6 +37,7 @@ end
 
 class StrongJSON::Type::Literal<'t>
   include Match
+  include WithAlias
 
   attr_reader value: 't
 
@@ -38,6 +47,7 @@ end
 
 class StrongJSON::Type::Array<'t>
   include Match
+  include WithAlias
 
   @type: _Schema<'t>
 
@@ -47,6 +57,7 @@ end
 
 class StrongJSON::Type::Object<'t>
   include Match
+  include WithAlias
 
   attr_reader fields: Hash<Symbol, _Schema<any>>
   attr_reader ignored_attributes: :any | Set<Symbol> | nil
@@ -66,6 +77,7 @@ type StrongJSON::Type::detector = ^(any) -> _Schema<any>?
 
 class StrongJSON::Type::Enum<'t>
   include Match
+  include WithAlias
 
   attr_reader types: ::Array<_Schema<any>>
   attr_reader detector: detector?

--- a/sig/type.rbi
+++ b/sig/type.rbi
@@ -59,12 +59,15 @@ class StrongJSON::Type::Object<'t>
   def except: (*Symbol) -> Object<any>
 end
 
+type StrongJSON::Type::detector = ^(any) -> _Schema<any>?
+
 class StrongJSON::Type::Enum<'t>
   include Match
 
   attr_reader types: ::Array<_Schema<any>>
+  attr_reader detector: detector?
 
-  def initialize: (::Array<_Schema<any>>) -> any
+  def initialize: (::Array<_Schema<any>>, ?detector?) -> any
   def coerce: (any, ?path: ::Array<Symbol>) -> 't
 end
 

--- a/spec/array_spec.rb
+++ b/spec/array_spec.rb
@@ -21,19 +21,19 @@ describe StrongJSON::Type::Array, "#coerce" do
   it "reject non array" do
     type = StrongJSON::Type::Array.new(StrongJSON::Type::Base.new(:number))
 
-    expect { type.coerce({}) }.to raise_error(StrongJSON::Type::Error)
+    expect { type.coerce({}) }.to raise_error(StrongJSON::Type::TypeError)
   end
 
   it "reject membership" do
     type = StrongJSON::Type::Array.new(StrongJSON::Type::Base.new(:number))
 
-    expect { type.coerce(["a"]) }.to raise_error(StrongJSON::Type::Error)
+    expect { type.coerce(["a"]) }.to raise_error(StrongJSON::Type::TypeError)
   end
 
   it "rejects nil" do
     type = StrongJSON::Type::Array.new(StrongJSON::Type::Base.new(:number))
 
-    expect { type.coerce(nil) }.to raise_error(StrongJSON::Type::Error)
+    expect { type.coerce(nil) }.to raise_error(StrongJSON::Type::TypeError)
   end
 
   describe "=~" do

--- a/spec/basetype_spec.rb
+++ b/spec/basetype_spec.rb
@@ -2,14 +2,6 @@ require "strong_json"
 
 describe StrongJSON::Type::Base do
   describe "#test" do
-    context ":ignored" do
-      let (:type) { StrongJSON::Type::Base.new(:ignored) }
-
-      it "can not be placed on toplevel" do
-        expect { type.coerce(3) }.to raise_error(StrongJSON::Type::IllegalTopTypeError)
-      end
-    end
-
     context ":number" do
       let (:type) { StrongJSON::Type::Base.new(:number) }
       

--- a/spec/basetype_spec.rb
+++ b/spec/basetype_spec.rb
@@ -170,4 +170,20 @@ describe StrongJSON::Type::Base do
       end
     end
   end
+
+  describe "alias" do
+    let (:type) { StrongJSON::Type::Base.new(:number) }
+
+    it "returns nil" do
+      expect(type.alias).to be_nil
+    end
+
+    describe "with_alias" do
+      let (:aliased_type) { type.with_alias(:count) }
+
+      it "returns alias name" do
+        expect(aliased_type.alias).to eq(:count)
+      end
+    end
+  end
 end

--- a/spec/basetype_spec.rb
+++ b/spec/basetype_spec.rb
@@ -6,7 +6,7 @@ describe StrongJSON::Type::Base do
       let (:type) { StrongJSON::Type::Base.new(:ignored) }
 
       it "can not be placed on toplevel" do
-        expect { type.coerce(3, path: []) }.to raise_error(StrongJSON::Type::IllegalTypeError)
+        expect { type.coerce(3) }.to raise_error(StrongJSON::Type::IllegalTopTypeError)
       end
     end
 

--- a/spec/enum_spec.rb
+++ b/spec/enum_spec.rb
@@ -22,14 +22,28 @@ describe StrongJSON::Type::Enum do
 
   describe "#coerce" do
     let (:type) {
-      StrongJSON::Type::Enum.new([
-                                   StrongJSON::Type::Object.new(id: StrongJSON::Type::Literal.new("id1"),
-                                                                value: StrongJSON::Type::Base.new(:string)),
-                                   StrongJSON::Type::Object.new(id: StrongJSON::Type::Base.new(:string),
-                                                                value: StrongJSON::Type::Base.new(:symbol)),
-                                   StrongJSON::Type::Optional.new(StrongJSON::Type::Literal.new(3)),
-                                   StrongJSON::Type::Literal.new(false),
-                                 ])
+      StrongJSON::Type::Enum.new(
+        [
+          StrongJSON::Type::Object.new(
+            {
+              id: StrongJSON::Type::Literal.new("id1"),
+              value: StrongJSON::Type::Base.new(:string)
+            },
+            ignored_attributes: nil,
+            prohibited_attributes: Set.new
+          ),
+          StrongJSON::Type::Object.new(
+            {
+              id: StrongJSON::Type::Base.new(:string),
+              value: StrongJSON::Type::Base.new(:symbol)
+            },
+            ignored_attributes: nil,
+            prohibited_attributes: Set.new
+          ),
+          StrongJSON::Type::Optional.new(StrongJSON::Type::Literal.new(3)),
+          StrongJSON::Type::Literal.new(false),
+        ]
+      )
     }
 
     it "returns object with string value" do
@@ -55,13 +69,23 @@ describe StrongJSON::Type::Enum do
     context "with detector" do
       let(:regexp_pattern) {
         StrongJSON::Type::Object.new(
-          regexp: StrongJSON::Type::Base.new(:string),
-          option: StrongJSON::Type::Base.new(:string),
-          )
+          {
+            regexp: StrongJSON::Type::Base.new(:string),
+            option: StrongJSON::Type::Base.new(:string),
+          },
+          ignored_attributes: nil,
+          prohibited_attributes: Set.new
+        )
       }
 
       let(:literal_pattern) {
-        StrongJSON::Type::Object.new(literal: StrongJSON::Type::Base.new(:string))
+        StrongJSON::Type::Object.new(
+          {
+            literal: StrongJSON::Type::Base.new(:string)
+          },
+          ignored_attributes: nil,
+          prohibited_attributes: Set.new
+        )
       }
 
       let(:type) {

--- a/spec/enum_spec.rb
+++ b/spec/enum_spec.rb
@@ -49,7 +49,7 @@ describe StrongJSON::Type::Enum do
     end
 
     it "raises error" do
-      expect { type.coerce(3.14) }.to raise_error(StrongJSON::Type::Error)
+      expect { type.coerce(3.14) }.to raise_error(StrongJSON::Type::TypeError)
     end
 
     context "with detector" do
@@ -91,8 +91,8 @@ describe StrongJSON::Type::Enum do
 
       it "raises error with base type" do
         expect {
-          type.coerce({ regexp: "foo", option: 3 })
-        }.to raise_error(StrongJSON::Type::Error) {|x|
+          type.coerce({ regexp: "foo", option: 123 })
+        }.to raise_error(StrongJSON::Type::TypeError) {|x|
           expect(x.type).to be_a(StrongJSON::Type::Base)
         }
       end
@@ -100,7 +100,7 @@ describe StrongJSON::Type::Enum do
       it "raises error with enum type" do
         expect {
           type.coerce({ option: 3 })
-        }.to raise_error(StrongJSON::Type::Error) {|x|
+        }.to raise_error(StrongJSON::Type::TypeError) {|x|
           expect(x.type).to eq(type)
         }
       end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,8 +1,66 @@
-describe StrongJSON::Type::Error do
+require "strong_json"
+
+describe StrongJSON::Type::ErrorPath do
+  ErrorPath = StrongJSON::Type::ErrorPath
   include StrongJSON::Types
 
-  it "hgoehoge" do
-    exn = StrongJSON::Type::Error.new(value: [], type: array(numeric), path: ["a",1,"b"])
-    expect(exn.to_s).to be_a(String)
+  describe "root path" do
+    let(:path) { ErrorPath.root(string) }
+
+    it "does not have parent" do
+      expect(path.parent).to be_nil
+    end
+
+    it "has type" do
+      expect(path.type).to be_a(StrongJSON::Type::Base)
+    end
+
+    it "prints" do
+      expect(path.to_s).to eq("$")
+    end
+  end
+
+  describe "appended path" do
+    let(:path) {
+      ErrorPath.root(object(foo: array(number)))
+        .dig(key: :foo, type: array(number))
+        .dig(key: 0, type: number)
+    }
+
+    it "does have parent" do
+      expect(path.parent).to be_a(Array)
+      expect(path.parent[0]).to eq(0)
+      expect(path.parent[1]).to be_a(ErrorPath)
+    end
+
+    it "has type" do
+      expect(path.type).to be_a(StrongJSON::Type::Base)
+    end
+
+    it "prints" do
+      expect(path.to_s).to eq("$.foo[0]")
+    end
+  end
+
+  describe "expanded path" do
+    let(:path) {
+      ErrorPath.root(array(enum(number, string)))
+        .dig(key: 0, type: enum(number, string))
+        .expand(type: string)
+    }
+
+    it "does have parent" do
+      expect(path.parent).to be_a(Array)
+      expect(path.parent[0]).to be_nil
+      expect(path.parent[1]).to be_a(ErrorPath)
+    end
+
+    it "has type" do
+      expect(path.type).to be_a(StrongJSON::Type::Base)
+    end
+
+    it "prints" do
+      expect(path.to_s).to eq("$[0]")
+    end
   end
 end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -4,12 +4,89 @@ describe "StrongJSON.new" do
   it "tests the structure of a JSON object" do
     s = StrongJSON.new do
       let :item, object(name: string, count: numeric, price: numeric).ignore(Set.new([:comment]))
-      let :checkout, object(items: array(item), change: optional(number), type: enum(literal(1), symbol))
+      let :items, array(item)
+      let :checkout,
+          object(items: items,
+                 change: optional(number),
+                 type: enum(literal(1), symbol),
+                 customer: object?(
+                   name: string,
+                   id: string,
+                   birthday: string,
+                   gender: enum(literal("man"), literal("woman"), literal("other")),
+                   phone: string
+                 )
+          )
     end
 
     expect(
       s.checkout.coerce(items: [{ name: "test", count: 1, price: "2.33", comment: "dummy" }], type: 1)
-    ).to eq(items: [ { name: "test", count: 1, price: "2.33" }], type: 1, change: nil)
+    ).to eq(items: [ { name: "test", count: 1, price: "2.33" }], type: 1, change: nil, customer: nil)
+
+    expect {
+      s.checkout.coerce(items: [{ name: "test", count: 1, price: [], comment: "dummy" }], type: 1)
+    }.to raise_error(StrongJSON::Type::TypeError) {|e|
+      expect(e.path.to_s).to eq("$.items[0].price")
+      expect(e.type).to be_a(StrongJSON::Type::Base)
+
+      expect(e.message).to eq("TypeError at $.items[0].price: expected=numeric, value=[]")
+      reporter = StrongJSON::ErrorReporter.new(path: e.path)
+      expect(reporter.to_s).to eq(<<MSG.chop)
+ "price" expected to be numeric
+  0 expected to be item
+   "items" expected to be items
+    $ expected to be checkout
+
+Where:
+  item = { "name": string, "count": numeric, "price": numeric }
+  items = array(item)
+  checkout = {
+    "items": items,
+    "change": optional(number),
+    "type": enum(1, symbol),
+    "customer": optional(
+      {
+        "name": string,
+        "id": string,
+        "birthday": string,
+        "gender": enum("man", "woman", "other"),
+        "phone": string
+      }
+    )
+  }
+MSG
+    }
+
+    expect {
+      s.checkout.coerce(items: [], change: "", type: 1)
+    }.to raise_error(StrongJSON::Type::TypeError) {|e|
+      expect(e.path.to_s).to eq("$.change")
+      expect(e.type).to be_a(StrongJSON::Type::Base)
+
+      expect(e.message).to eq('TypeError at $.change: expected=number, value=""')
+      reporter = StrongJSON::ErrorReporter.new(path: e.path)
+      expect(reporter.to_s).to eq(<<MSG.chop)
+ Expected to be number
+  "change" expected to be optional(number)
+   $ expected to be checkout
+
+Where:
+  checkout = {
+    "items": items,
+    "change": optional(number),
+    "type": enum(1, symbol),
+    "customer": optional(
+      {
+        "name": string,
+        "id": string,
+        "birthday": string,
+        "gender": enum("man", "woman", "other"),
+        "phone": string
+      }
+    )
+  }
+MSG
+    }
   end
 
   it "tests enums" do
@@ -39,5 +116,36 @@ describe "StrongJSON.new" do
       expect(s.count.alias).to eq(:count)
       expect(s.age.alias).to eq(:age)
     end
+  end
+
+  it "pretty print" do
+    s = StrongJSON.new do
+      let :regexp_pattern, object(pattern: string, multiline: boolean?, case_sensitive: boolean?)
+      let :token_pattern, object(token: string, case_sensitive: boolean?)
+      let :literal_pattern, object(literal: string)
+      let :string_pattern, string
+      let :pattern, enum(regexp_pattern, token_pattern, literal_pattern, string_pattern, string?)
+
+      let :rule, object(pattern: pattern, glob: enum?(string, array(string)))
+    end
+
+    expect { s.rule.coerce({ pattern: { pattern: 3 } }) }.to raise_error(StrongJSON::Type::TypeError) {|e|
+      expect(e.message).to eq("TypeError at $.pattern: expected=pattern, value={:pattern=>3}")
+      reporter = StrongJSON::ErrorReporter.new(path: e.path)
+      expect(reporter.to_s).to eq(<<MSG.chop)
+ "pattern" expected to be pattern
+  $ expected to be rule
+
+Where:
+  pattern = enum(
+    regexp_pattern,
+    token_pattern,
+    literal_pattern,
+    string_pattern,
+    optional(string)
+  )
+  rule = { "pattern": pattern, "glob": optional(enum(string, array(string))) }
+MSG
+    }
   end
 end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -28,4 +28,16 @@ describe "StrongJSON.new" do
       expect(e.path.to_s).to eq("$.e2")
     }
   end
+
+  describe "#let" do
+    it "defines aliased type" do
+      s = StrongJSON.new do
+        let :count, number
+        let :age, number
+      end
+
+      expect(s.count.alias).to eq(:count)
+      expect(s.age.alias).to eq(:age)
+    end
+  end
 end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -3,11 +3,13 @@ require "strong_json"
 describe "StrongJSON.new" do
   it "tests the structure of a JSON object" do
     s = StrongJSON.new do
-      let :item, object(name: string, count: numeric, price: numeric, comment: ignored)
+      let :item, object(name: string, count: numeric, price: numeric).ignore(Set.new([:comment]))
       let :checkout, object(items: array(item), change: optional(number), type: enum(literal(1), symbol))
     end
 
-    expect(s.checkout.coerce(items: [ { name: "test", count: 1, price: "2.33", comment: "dummy" }], type: 1)).to eq(items: [ { name: "test", count: 1, price: "2.33" }], type: 1)
+    expect(
+      s.checkout.coerce(items: [{ name: "test", count: 1, price: "2.33", comment: "dummy" }], type: 1)
+    ).to eq(items: [ { name: "test", count: 1, price: "2.33" }], type: 1, change: nil)
   end
 
   it "tests enums" do
@@ -15,8 +17,8 @@ describe "StrongJSON.new" do
       let :enum, object(e1: enum(boolean, number), e2: enum?(literal(1), literal(2)))
     end
 
-    expect(s.enum.coerce(e1: false)).to eq(e1: false)
-    expect(s.enum.coerce(e1: 0)).to eq(e1: 0)
+    expect(s.enum.coerce(e1: false)).to eq(e1: false, e2: nil)
+    expect(s.enum.coerce(e1: 0)).to eq(e1: 0, e2: nil)
     expect(s.enum.coerce(e1: 0, e2: 1)).to eq(e1: 0, e2: 1)
     expect(s.enum.coerce(e1: 0, e2: 2)).to eq(e1: 0, e2: 2)
     expect{ s.enum.coerce(e1: "", e2: 3) }.to raise_error(StrongJSON::Type::TypeError) {|e|

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -19,7 +19,11 @@ describe "StrongJSON.new" do
     expect(s.enum.coerce(e1: 0)).to eq(e1: 0)
     expect(s.enum.coerce(e1: 0, e2: 1)).to eq(e1: 0, e2: 1)
     expect(s.enum.coerce(e1: 0, e2: 2)).to eq(e1: 0, e2: 2)
-    expect{ s.enum.coerce(e1: "", e2: 3) }.to raise_error(StrongJSON::Type::Error)
-    expect{ s.enum.coerce(e1: false, e2: "") }.to raise_error(StrongJSON::Type::Error)
+    expect{ s.enum.coerce(e1: "", e2: 3) }.to raise_error(StrongJSON::Type::TypeError) {|e|
+      expect(e.path.to_s).to eq("$.e1")
+    }
+    expect{ s.enum.coerce(e1: false, e2: "") }.to raise_error(StrongJSON::Type::TypeError) {|e|
+      expect(e.path.to_s).to eq("$.e2")
+    }
   end
 end

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -3,14 +3,26 @@ require "strong_json"
 describe StrongJSON::Type::Object do
   describe "#coerce" do
     it "accepts value" do
-      type = StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:numeric),
-                                          b: StrongJSON::Type::Base.new(:string))
+      type = StrongJSON::Type::Object.new(
+        {
+          a: StrongJSON::Type::Base.new(:numeric),
+          b: StrongJSON::Type::Base.new(:string)
+        },
+        ignored_attributes: nil,
+        prohibited_attributes: Set.new
+      )
 
       expect(type.coerce(a: 123, b: "test")).to eq(a: 123, b: "test")
     end
 
     it "rejects unspecified fields" do
-      type = StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:numeric))
+      type = StrongJSON::Type::Object.new(
+        {
+          a: StrongJSON::Type::Base.new(:numeric)
+        },
+        ignored_attributes: nil,
+        prohibited_attributes: Set.new
+      )
 
       expect { type.coerce(a:123, b:true) }.to raise_error(StrongJSON::Type::UnexpectedAttributeError) {|e|
         expect(e.path.to_s).to eq("$")
@@ -18,88 +30,131 @@ describe StrongJSON::Type::Object do
       }
     end
 
-    describe "ignored" do
-      it "ignores field with any value" do
-        type = StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:numeric), b: StrongJSON::Type::Base.new(:ignored))
-        expect(type.coerce(a: 123, b: true)).to eq(a: 123)
-      end
-
-      it "accepts if it does not contains the field" do
-        type = StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:numeric), b: StrongJSON::Type::Base.new(:ignored))
-        expect(type.coerce(a: 123)).to eq(a: 123)
-      end
-    end
-
     it "rejects objects with missing fields" do
-      type = StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:numeric))
+      type = StrongJSON::Type::Object.new(
+        {
+          a: StrongJSON::Type::Base.new(:numeric)
+        },
+        ignored_attributes: nil,
+        prohibited_attributes: Set.new
+      )
 
       expect{ type.coerce(b: "test") }.to raise_error(StrongJSON::Type::UnexpectedAttributeError) {|e|
         expect(e.path.to_s).to eq("$")
         expect(e.attribute).to eq(:b)
       }
     end
+
+    describe "ignored_attributes" do
+      context "when ignored_attributes are given as Set" do
+        let(:type) {
+          StrongJSON::Type::Object.new(
+            {
+              a: StrongJSON::Type::Base.new(:numeric)
+            },
+            ignored_attributes: Set.new([:b]),
+            prohibited_attributes: Set.new
+          )
+        }
+
+        it "ignores field with any value" do
+          expect(type.coerce(a: 123, b: true)).to eq(a: 123)
+        end
+
+        it "accepts if it does not contains the field" do
+          expect(type.coerce(a: 123)).to eq(a: 123)
+        end
+      end
+
+      context "when ignored_attributes is nil" do
+        let(:type) {
+          StrongJSON::Type::Object.new(
+            {
+              a: StrongJSON::Type::Base.new(:numeric)
+            },
+            ignored_attributes: nil,
+            prohibited_attributes: Set.new
+          )
+        }
+
+        it "ignores field with any value" do
+          expect {
+            type.coerce(a: 123, b: true)
+          }.to raise_error(StrongJSON::Type::UnexpectedAttributeError)
+        end
+      end
+
+      context "when ignored_attributes is :any" do
+        let(:type) {
+          StrongJSON::Type::Object.new(
+            {
+              a: StrongJSON::Type::Base.new(:numeric)
+            },
+            ignored_attributes: :any,
+            prohibited_attributes: Set.new
+          )
+        }
+
+        it "ignores field with any value" do
+          expect(type.coerce(a: 123, b: true)).to eq(a: 123)
+        end
+      end
+    end
+
+    describe "prohibited_attributes" do
+      let(:type) {
+        StrongJSON::Type::Object.new(
+          {
+            a: StrongJSON::Type::Base.new(:numeric)
+          },
+          ignored_attributes: :any,
+          prohibited_attributes: Set.new([:x])
+        )
+      }
+
+      it "raises error if the attribute is given" do
+        expect {
+          type.coerce(a:123, b:true, x: [])
+        }.to raise_error(StrongJSON::Type::UnexpectedAttributeError)
+      end
+    end
   end
 
   describe "optional" do
+    let(:type) {
+      StrongJSON::Type::Object.new(
+        {
+          a: StrongJSON::Type::Optional.new(StrongJSON::Type::Base.new(:numeric))
+        },
+        ignored_attributes: nil,
+        prohibited_attributes: Set.new
+      )
+    }
+
     it "accepts missing field if optional" do
-      type = StrongJSON::Type::Object.new(a: StrongJSON::Type::Optional.new(StrongJSON::Type::Base.new(:numeric)))
-      expect(type.coerce({})).to eq({})
+      expect(type.coerce({})).to eq(a: nil)
     end
 
     it "preserves if present" do
-      type = StrongJSON::Type::Object.new(a: StrongJSON::Type::Optional.new(StrongJSON::Type::Base.new(:numeric)))
       expect(type.coerce({ a: "-123" })).to eq({ a: "-123" })
     end
 
     it "preserves nil if present" do
-      type = StrongJSON::Type::Object.new(a: StrongJSON::Type::Optional.new(StrongJSON::Type::Base.new(:numeric)))
       expect(type.coerce({ a: nil })).to eq({ a: nil })
     end
   end
 
-  describe "#merge" do
-    let (:type) { StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:numeric)) }
-
-    it "adds field" do
-      ty2 = type.merge(b: StrongJSON::Type::Base.new(:string))
-
-      expect(ty2.coerce(a: 123, b: "test")).to eq(a: 123, b: "test")
-    end
-
-    it "overrides field" do
-      ty2 = type.merge(a: StrongJSON::Type::Base.new(:prohibited))
-
-      expect{ ty2.coerce(a: 123) }.to raise_error(StrongJSON::Type::TypeError) {|e|
-        expect(e.path.to_s).to eq("$.a")
-      }
-    end
-
-    it "adds field via object" do
-      ty2 = type.merge(StrongJSON::Type::Object.new(b: StrongJSON::Type::Base.new(:string)))
-
-      expect(ty2.coerce(a: 123, b: "test")).to eq(a: 123, b: "test")
-    end
-
-    it "overrides field via object" do
-      ty2 = type.merge(StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:prohibited)))
-
-      expect{ ty2.coerce(a: 123) }.to raise_error(StrongJSON::Type::TypeError) {|e|
-        expect(e.path.to_s).to eq("$.a")
-      }
-    end
-  end
-
-  describe "#except" do
-    let (:type) { StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:numeric), b: StrongJSON::Type::Base.new(:string)) }
-
-    it "return object which ignores given fields but preserve others" do
-      ty2 = type.except(:a)
-      expect(ty2.coerce(b: "test")).to eq({ b: "test" })
-    end
-  end
-
   describe "=~" do
-    let (:type) { StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:numeric), b: StrongJSON::Type::Base.new(:string)) }
+    let (:type) {
+      StrongJSON::Type::Object.new(
+        {
+          a: StrongJSON::Type::Base.new(:numeric),
+          b: StrongJSON::Type::Base.new(:string)
+        },
+        ignored_attributes: nil,
+        prohibited_attributes: Set.new
+      )
+    }
 
     it "returns true for valid object" do
       expect(type =~ { a: 3, b: "foo" }).to be_truthy

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -12,7 +12,10 @@ describe StrongJSON::Type::Object do
     it "rejects unspecified fields" do
       type = StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:numeric))
 
-      expect { type.coerce(a:123, b:true) }.to raise_error(StrongJSON::Type::UnexpectedFieldError)
+      expect { type.coerce(a:123, b:true) }.to raise_error(StrongJSON::Type::UnexpectedAttributeError) {|e|
+        expect(e.path.to_s).to eq("$")
+        expect(e.attribute).to eq(:b)
+      }
     end
 
     describe "ignored" do
@@ -30,7 +33,10 @@ describe StrongJSON::Type::Object do
     it "rejects objects with missing fields" do
       type = StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:numeric))
 
-      expect{ type.coerce(b: "test") }.to raise_error(StrongJSON::Type::UnexpectedFieldError)
+      expect{ type.coerce(b: "test") }.to raise_error(StrongJSON::Type::UnexpectedAttributeError) {|e|
+        expect(e.path.to_s).to eq("$")
+        expect(e.attribute).to eq(:b)
+      }
     end
   end
 
@@ -63,7 +69,9 @@ describe StrongJSON::Type::Object do
     it "overrides field" do
       ty2 = type.merge(a: StrongJSON::Type::Base.new(:prohibited))
 
-      expect{ ty2.coerce(a: 123) }.to raise_error(StrongJSON::Type::Error)
+      expect{ ty2.coerce(a: 123) }.to raise_error(StrongJSON::Type::TypeError) {|e|
+        expect(e.path.to_s).to eq("$.a")
+      }
     end
 
     it "adds field via object" do
@@ -75,7 +83,9 @@ describe StrongJSON::Type::Object do
     it "overrides field via object" do
       ty2 = type.merge(StrongJSON::Type::Object.new(a: StrongJSON::Type::Base.new(:prohibited)))
 
-      expect{ ty2.coerce(a: 123) }.to raise_error(StrongJSON::Type::Error)
+      expect{ ty2.coerce(a: 123) }.to raise_error(StrongJSON::Type::TypeError) {|e|
+        expect(e.path.to_s).to eq("$.a")
+      }
     end
   end
 

--- a/spec/optional_spec.rb
+++ b/spec/optional_spec.rb
@@ -13,7 +13,10 @@ describe StrongJSON::Type::Optional, "#coerce" do
     end
 
     it "rejects string" do
-      expect { type.coerce("a") }.to raise_error(StrongJSON::Type::Error)
+      expect { type.coerce("a") }.to raise_error(StrongJSON::Type::TypeError) {|e|
+        expect(e.path.to_s).to eq("$")
+        expect(e.type).to be_a(StrongJSON::Type::Base)
+      }
     end
   end
 end


### PR DESCRIPTION
Error reporting of `enum` types are terrible now. This series of patches improves it.

The type error will look like the following, which I hope users will understand what happens with:

```
Invalid config: TypeError at $.rules[2].glob[1]: expected=one_glob, value=3
 1 expected to be one_glob
  Expected to be array(one_glob)
   Expected to be glob
    "glob" expected to be optional(glob)
     Expected to be negative_rule
      2 expected to be rule
       "rules" expected to be rules
        $ expected to be config

Where:
  one_glob = enum(glob_obj, string)
  glob = enum(array(one_glob), one_glob)
  negative_rule = {
    "id": string,
    "not": { "pattern": enum(array(pattern), pattern) },
    "message": string,
    "justification": optional(enum(array(string), string)),
    "glob": optional(glob),
    "pass": optional(enum(array(string), string)),
    "fail": optional(enum(array(string), string))
  }
  rule = enum(positive_rule, negative_rule)
  rules = array(rule)
  config = {
    "rules": rules,
    "import": optional(imports),
    "exclude": optional(exclude)
  }
```

This PR contains the following changes:

* Add `detector` attribute for `enum` types, which helps determine which of the possible types the value has
* Revise `object` type representation, which deletes `ignored` type (incompatibility 🚨)
* Add `alias` to all of the types, which has the name given by `let` method call
* Add `ErrorReporter` to print the error message above