### PR TITLE
Revise object

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,26 +59,20 @@ If an attribute has a value which does not match with given type, the `coerce` m
 
 #### Ignoring unknown attributes
 
-`Object` type ignores unknown attributes by default.
-You can reject the unknown attributes.
+You can use `ignore` method to ignore unknown attributes.
 
 ```
-object(attrs).ignore(Set.new)       # Ignores nothing (== raise an error)
-object(attrs).ignore!(Set.new)      # Destructive version
+object(attrs).ignore()                     # Ignores all unknown attributes.
+object(attrs).ignore(:x, :y)               # Ignores :x and :y, but rejects other unknown attributes.
+object(attrs).ignore(except: Set[:x, :y])  # Rejects :x and :y, but ignores other unknown attributes.
 ```
 
-You can selectively ignore attributes:
+`Object` also provides `reject` method to do the opposite.
 
 ```
-object(attrs).ignore(Set.new([:a, :b, :c]))   # Ignores only :a, :b, and :c
-object(attrs).ignore(:any)                    # Ignores everything (default)
-```
-
-`Object` also has `prohibit` method to specify attributes to make the type check failed.
-
-```
-object(attrs).prohibit(Set.new([:created_at, :updated_at]))   # Make type check failed if :created_at or :updated_at included
-object(attrs).prohibit!(Set.new([:created_at, :updated_at]))  # Destructive version
+object(attrs).reject()                     # Rejects all unknown attributes. (default)
+object(attrs).reject(:x, :y)               # Rejects :x and :y, but ignores other unknown attributes.
+object(attrs).reject(except: Set[:x, :y])  # Ignores :x and :y, but rejects other unknown attributes.
 ```
 
 ### array(type)

--- a/lib/strong_json/types.rb
+++ b/lib/strong_json/types.rb
@@ -3,9 +3,9 @@ class StrongJSON
     # @type method object: (?Hash<Symbol, ty>) -> Type::Object<any>
     def object(fields = {})
       if fields.empty?
-        Type::Object.new(fields, ignored_attributes: nil, prohibited_attributes: Set.new)
+        Type::Object.new(fields, on_unknown: :ignore, exceptions: Set.new)
       else
-        Type::Object.new(fields, ignored_attributes: :any, prohibited_attributes: Set.new)
+        Type::Object.new(fields, on_unknown: :reject, exceptions: Set.new)
       end
     end
 

--- a/sig/type.rbi
+++ b/sig/type.rbi
@@ -60,16 +60,26 @@ class StrongJSON::Type::Object<'t>
   include WithAlias
 
   attr_reader fields: ::Hash<Symbol, _Schema<any>>
-  attr_reader ignored_attributes: :any | Set<Symbol> | nil
-  attr_reader prohibited_attributes: Set<Symbol>
+  attr_reader on_unknown: :ignore | :reject
+  attr_reader exceptions: Set<Symbol>
 
-  def initialize: (::Hash<Symbol, _Schema<'t>>, ignored_attributes: :any | Set<Symbol> | nil, prohibited_attributes: Set<Symbol>) -> any
+  def initialize: (::Hash<Symbol, _Schema<'t>>, on_unknown: :ignore | :reject, exceptions: Set<Symbol>) -> any
   def coerce: (any, ?path: ErrorPath) -> 't
 
-  def ignore: (:any | Set<Symbol> | nil) -> self
-  def ignore!: (:any | Set<Symbol> | nil) -> self
-  def prohibit: (Set<Symbol>) -> self
-  def prohibit!: (Set<Symbol>) -> self
+  # If no argument is given, it ignores all unknown attributes.
+  # If `Symbol`s are given, it ignores the listed attributes, but rejects if other unknown attributes are detected.
+  # If `except:` is specified, it rejects attributes listed in `except` are detected, but ignores other unknown attributes.
+  def ignore: () -> self
+            | (*Symbol) -> self
+            | (?except: Set<Symbol>) -> self
+
+  # If no argument is given, it rejects on any unknown attribute.
+  # If `Symbol`s are given, it rejects the listed attributes are detected, but ignores other unknown attributes.
+  # If `except:` is specified, it ignores given attributes, but rejects if other unknown attributes are detected.
+  def reject: () -> self
+            | (*Symbol) -> self
+            | (?except: Set<Symbol>) -> self
+
   def update_fields: <'x> { (::Hash<Symbol, _Schema<any>>) -> void } -> Object<'x>
 end
 

--- a/spec/enum_spec.rb
+++ b/spec/enum_spec.rb
@@ -29,16 +29,16 @@ describe StrongJSON::Type::Enum do
               id: StrongJSON::Type::Literal.new("id1"),
               value: StrongJSON::Type::Base.new(:string)
             },
-            ignored_attributes: nil,
-            prohibited_attributes: Set.new
+            on_unknown: :raise,
+            exceptions: Set[]
           ),
           StrongJSON::Type::Object.new(
             {
               id: StrongJSON::Type::Base.new(:string),
               value: StrongJSON::Type::Base.new(:symbol)
             },
-            ignored_attributes: nil,
-            prohibited_attributes: Set.new
+            on_unknown: :raise,
+            exceptions: Set[]
           ),
           StrongJSON::Type::Optional.new(StrongJSON::Type::Literal.new(3)),
           StrongJSON::Type::Literal.new(false),
@@ -73,8 +73,8 @@ describe StrongJSON::Type::Enum do
             regexp: StrongJSON::Type::Base.new(:string),
             option: StrongJSON::Type::Base.new(:string),
           },
-          ignored_attributes: nil,
-          prohibited_attributes: Set.new
+          on_unknown: :raise,
+          exceptions: Set[]
         )
       }
 
@@ -83,8 +83,8 @@ describe StrongJSON::Type::Enum do
           {
             literal: StrongJSON::Type::Base.new(:string)
           },
-          ignored_attributes: nil,
-          prohibited_attributes: Set.new
+          on_unknown: :raise,
+          exceptions: Set[]
         )
       }
 

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -3,7 +3,7 @@ require "strong_json"
 describe "StrongJSON.new" do
   it "tests the structure of a JSON object" do
     s = StrongJSON.new do
-      let :item, object(name: string, count: numeric, price: numeric).ignore(Set.new([:comment]))
+      let :item, object(name: string, count: numeric, price: numeric).ignore(:comment)
       let :items, array(item)
       let :checkout,
           object(items: items,


### PR DESCRIPTION
Provide `ignore` and `reject` methods to simplify the API.

We generally want to:

* _Ignore_ these attributes, but reject others, or
* _Reject_ these attributes, but ignore others.

It implies we don't have to specify both of the _ignored_ and _rejected_ attributes.