### PR TITLE
Fix verbose warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/vendor/bundle/
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/lib/strong_json/error_reporter.rb
+++ b/lib/strong_json/error_reporter.rb
@@ -8,7 +8,7 @@ class StrongJSON
     end
 
     def to_s
-      format() unless @string
+      format() unless defined?(@string)
       @string
     end
 

--- a/lib/strong_json/type.rb
+++ b/lib/strong_json/type.rb
@@ -15,7 +15,7 @@ class StrongJSON
 
     module WithAlias
       def alias
-        @alias
+        defined?(@alias) ? @alias : nil
       end
 
       def with_alias(name)


### PR DESCRIPTION
This fixes the 2 warnings below:

> /path/to/strong_json/lib/strong_json/type.rb:18: warning: instance variable @alias not initialized
> /path/to/strong_json/lib/strong_json/error_reporter.rb:11: warning: instance variable @string not initialized

Why?
----

`Rake::TestTask#warning` is `true` by default. So, in our project using `strong_json`, the `rake test` command outputs too many warnings, which hide important warnings.

See the Rake API doc below:
<https://www.rubydoc.info/gems/rake/12.3.2/Rake/TestTask#warning-instance_method>

Reproduction
--------

Run `bundle exec rspec --warnings` command. You will see too many warnings.
