### PR TITLE
Fix a scope bug of RBS

### DIFF
--- a/sig/type.rbs
+++ b/sig/type.rbs
@@ -79,7 +79,7 @@ class StrongJSON::Type::Object[T]
   def update_fields: [X] { (::Hash[Symbol, _Schema[untyped]]) -> void } -> Object[X]
 end
 
-type StrongJSON::Type::detector = ^(untyped) -> _Schema[untyped]?
+type StrongJSON::Type::Enum::detector = ^(untyped) -> StrongJson::_Schema[untyped]
 
 class StrongJSON::Type::Enum[T]
   include Match


### PR DESCRIPTION
The alias definition `type StrongJSON::Type::detector` cannot be
accessed in the scope of `class StrongJSON::Type::Enum[T]`.

This commit changes the alias to `StrongJSON::Type::Enum::detector`.