### PR TITLE
Add missing `require "set"`

### DIFF
--- a/lib/strong_json.rb
+++ b/lib/strong_json.rb
@@ -1,3 +1,4 @@
+require "set"
 require "strong_json/version"
 require "strong_json/type"
 require "strong_json/types"


### PR DESCRIPTION
StrongJSON uses `Set` internally, but `require "set"` is missing. So, `NameError` occurs in the following situation:

```console
$ docker run --rm -it rubylang/ruby:2.7.2-bionic bash

root@f4c2ed545b13:/# gem install strong_json
Fetching strong_json-2.1.2.gem
Successfully installed strong_json-2.1.2
1 gem installed

root@f4c2ed545b13:/# ruby -r strong_json -e 'StrongJSON.new { let :a, object }'
Traceback (most recent call last):
	5: from -e:1:in `<main>'
	4: from -e:1:in `new'
	3: from /usr/local/lib/ruby/gems/2.7.0/gems/strong_json-2.1.2/lib/strong_json.rb:9:in `initialize'
	2: from /usr/local/lib/ruby/gems/2.7.0/gems/strong_json-2.1.2/lib/strong_json.rb:9:in `instance_eval'
	1: from -e:1:in `block in <main>'
/usr/local/lib/ruby/gems/2.7.0/gems/strong_json-2.1.2/lib/strong_json/types.rb:5:in `object': uninitialized constant StrongJSON::Types::Set (NameError)
```

This change aims to fix the error above.