### PR TITLE
Fix Steep errors

### DIFF
--- a/lib/strong_json/type.rb
+++ b/lib/strong_json/type.rb
@@ -77,6 +77,8 @@ class StrongJSON
       def ==(other)
         if other.is_a?(Base)
           other.type == type
+        else
+          super
         end
       end
 
@@ -111,6 +113,8 @@ class StrongJSON
       def ==(other)
         if other.is_a?(Optional)
           other.type == type
+        else
+          super
         end
       end
 
@@ -178,6 +182,8 @@ class StrongJSON
       def ==(other)
         if other.is_a?(Array)
           other.type == type
+        else
+          super
         end
       end
 
@@ -281,6 +287,8 @@ class StrongJSON
           other.fields == fields &&
             other.on_unknown == on_unknown &&
             other.exceptions == exceptions
+        else
+          super
         end
       end
 
@@ -328,6 +336,8 @@ class StrongJSON
         if other.is_a?(Enum)
           other.types == types &&
             other.detector == detector
+        else
+          super
         end
       end
 
@@ -362,6 +372,8 @@ class StrongJSON
       def ==(other)
         if other.is_a?(Hash)
           other.type == type
+        else
+          super
         end
       end
     end


### PR DESCRIPTION
The following errors occur with the latest version 0.42.0 of Steep.
This change aims to fix them.

```console
$ bundle exec steep check
# Type checking files:

...............................................................F.

lib/strong_json/type.rb:77:6: [error] Cannot allow method body have type `(bool | nil)` because declared as type `bool`
│   (bool | nil) <: bool
│     (bool | nil) <: (true | false)
│       nil <: (true | false)
│         nil <: true
│
│ Diagnostic ID: Ruby::MethodBodyTypeMismatch
│
└       def ==(other)
        ~~~~~~~~~~~~~

lib/strong_json/type.rb:111:6: [error] Cannot allow method body have type `(bool | nil)` because declared as type `bool`
│   (bool | nil) <: bool
│     (bool | nil) <: (true | false)
│       nil <: (true | false)
│         nil <: true
│
│ Diagnostic ID: Ruby::MethodBodyTypeMismatch
│
└       def ==(other)
        ~~~~~~~~~~~~~

lib/strong_json/type.rb:178:6: [error] Cannot allow method body have type `(bool | nil)` because declared as type `bool`
│   (bool | nil) <: bool
│     (bool | nil) <: (true | false)
│       nil <: (true | false)
│         nil <: true
│
│ Diagnostic ID: Ruby::MethodBodyTypeMismatch
│
└       def ==(other)
        ~~~~~~~~~~~~~

lib/strong_json/type.rb:279:6: [error] Cannot allow method body have type `(bool | nil)` because declared as type `bool`
│   (bool | nil) <: bool
│     (bool | nil) <: (true | false)
│       nil <: (true | false)
│         nil <: true
│
│ Diagnostic ID: Ruby::MethodBodyTypeMismatch
│
└       def ==(other)
        ~~~~~~~~~~~~~

lib/strong_json/type.rb:327:6: [error] Cannot allow method body have type `(bool | nil)` because declared as type `bool`
│   (bool | nil) <: bool
│     (bool | nil) <: (true | false)
│       nil <: (true | false)
│         nil <: true
│
│ Diagnostic ID: Ruby::MethodBodyTypeMismatch
│
└       def ==(other)
        ~~~~~~~~~~~~~

lib/strong_json/type.rb:362:6: [error] Cannot allow method body have type `(bool | nil)` because declared as type `bool`
│   (bool | nil) <: bool
│     (bool | nil) <: (true | false)
│       nil <: (true | false)
│         nil <: true
│
│ Diagnostic ID: Ruby::MethodBodyTypeMismatch
│
└       def ==(other)
        ~~~~~~~~~~~~~

Detected 6 problems from 1 file
```